### PR TITLE
Add rspec-junit-formatter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --require spec_helper
+--format RspecJunitFormatter
+--out tmp/rspec<%= ENV["TEST_ENV_NUMBER"] %>.xml

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+  gem "rspec_junit_formatter"
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.4)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -185,6 +184,8 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -267,6 +268,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-assets-tether (>= 1.3.3)!
   rspec-rails
+  rspec_junit_formatter
   rubocop
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,19 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  # register around filter that captures stdout and stderr
+  config.around(:each) do |example|
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+
+    example.run
+
+    example.metadata[:stdout] = $stdout.string
+    example.metadata[:stderr] = $stderr.string
+
+    $stdout = STDOUT
+    $stderr = STDERR
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
I needed to add these configurations to rspec so that CircleCI could print out test results to the tmp folder with xml. 