### PR TITLE
Add GamesHelper methods for rendering pieces

### DIFF
--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -1,5 +1,13 @@
 @import "bootstrap";
 
+.red {
+  color: red;
+}
+
+.blue {
+  color: blue;
+}
+
 .white {
   border: 1px solid black;
   width: 5vw;

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
 module GamesHelper
+  include ActionView::Helpers::TagHelper
+
+  def get_piece(x, y, game)
+    game.pieces.where(x_position: x, y_position: y).first
+  end
+
+  def render_piece(x, y, game, color)
+    piece = get_piece(x, y, game)
+    tag.h1 piece.piece.to_s, class: color
+  end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,11 +22,20 @@
     <% 8.times do |y| %> 
       <div class="row justify-content-center">
         <% 8.times do |x| %>
+          <% piece = get_piece(x, y, @game) %>
           <% if x % 2 == 0 && y % 2 == 0 || x % 2 == 1 && y % 2 == 1 %>
             <div id="<%= x %>,<%= y %>" class="black">
+              <% if piece.present? %>
+                <% piece.piece > 5 ? color = 'blue' : color = 'red' %>
+                <%= render_piece(x, y, @game, color) %>
+              <% end %>
             </div>
           <% else %>
             <div id="<%= x %>,<%= y %>" class="white">
+              <% if piece.present? %>
+                <% piece.piece > 5 ? color = 'blue' : color = 'red' %>
+                <%= render_piece(x, y, @game, color) %>
+              <% end %>
             </div>
           <% end %>
         <% end %>

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
+include GamesHelper
 
 RSpec.describe GamesController, type: :controller do
   describe 'games#create action' do
     it 'should require users to be logged in' do
-      post :create, params:{ game:{ name: 'Test'}}
+      post :create, params: { game: { name: 'Test' } }
       expect(response).to redirect_to new_user_session_path
     end
 
@@ -13,8 +16,8 @@ RSpec.describe GamesController, type: :controller do
 
       post :create, params: {
         game: {
-          name: 'Test',
-        } 
+          name: 'Test'
+        }
       }
 
       game = Game.last
@@ -24,6 +27,32 @@ RSpec.describe GamesController, type: :controller do
       expect(game.name).to eq('Test')
       expect(game.creating_user_id).to eq(user.id)
       expect(game.pieces.count).to eq 32
+    end
+  end
+
+  describe 'games helper methods' do
+    context 'rendering pieces' do
+      it 'should render html' do
+        # TODO: This test will need to be updated in the future once we have actual game pieces to render
+        user = create(:user)
+        sign_in user
+
+        post :create, params: {
+          game: {
+            name: 'Test',
+          } 
+        }
+
+        game = Game.last
+
+        8.times do |y|
+          8.times do |x|
+            if get_piece(x, y, game).present?
+              expect(render_piece(x, y, game, 'blue')).to eq(tag.h1(get_piece(x, y, game).piece.to_s, class: 'blue'))
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This will render a number representation (using the Pieces table "piece" integer field) to show what piece is present at a specific coordinate (x, y).

edit: I used red(white) and blue(black) to distinguish the pieces for now as it is easier to see. We can change them to white/black once we have actual images to populate the tiles. 