### PR TITLE
Correct omniauth twitter

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.provider = auth.provider
       user.uid = auth.uid
-      user.email = auth.info.email
+      auth.provider == 'twitter' ? user.email = "#{auth.info.nickname}@twitter.com" : user.email = auth.info.email
       user.password = Devise.friendly_token[0, 20]
     end
   end

--- a/db/migrate/20200102010608_remove_omniauth_from_users.rb
+++ b/db/migrate/20200102010608_remove_omniauth_from_users.rb
@@ -1,0 +1,8 @@
+class RemoveOmniauthFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :token, :string
+    remove_column :users, :expires_at, :integer
+    remove_column :users, :expires, :boolean
+    remove_column :users, :refresh_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_31_214321) do
+ActiveRecord::Schema.define(version: 2020_01_02_010608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,10 +78,6 @@ ActiveRecord::Schema.define(version: 2019_12_31_214321) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
-    t.string "token"
-    t.integer "expires_at"
-    t.boolean "expires"
-    t.string "refresh_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
This branch fixes the issue where omni-auth twitter was not creating a user in the database through devise.

Devise currently requires that we have an e-mail in the format "xxxxx@xxxx.com" for a user to be created. The twitter API does not pass an e-mail back through (without going through a rigorous verification process which our app would not pass at this time). So I have made it to where it will take the persons twitter "nickname" and prepend that to "@twitter.com". This then allows the user to register on our site using twitter. 

I removed the token columns in the User table using a migration as well. This was causing some issues earlier, we do not need them for omniauth to function for facebook, google, or twitter. Please make sure to run migrations after pulling the master down locally once this branch is merged. 