### PR TITLE
Run check? methods after pawn promotion

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -67,12 +67,6 @@ class Game < ApplicationRecord
     pieces.select { |piece| piece.is_white? == white }
   end
 
-  def end_turn(check_response, current_user)
-    return 'Black King in Check.' if check_response == 'Enemy in Check.' && current_user.id == p1_id
-
-    'White King in Check.' if check_response == 'Enemy in Check.' && current_user.id == p2_id
-  end
-
   def populate_game
     # White Rooks
     pieces.create(x_position: 0, y_position: 0, piece_number: 0, type: 'Rook')

--- a/app/views/pieces/promotion.js.erb
+++ b/app/views/pieces/promotion.js.erb
@@ -4,3 +4,6 @@ $('[data-piece-id="<%= @piece.id %>"]')
               class: "piece", \
               data: { piece_id: @piece.id, x_coord: @piece.x_position, y_coord: @piece.y_position } %>');
 init_draggables_and_droppables();
+
+<% flash.now[:alert] << @game.check_message(current_user) if @game.check?(!@piece.is_white?) %>
+$('.game-board').html('<%= j (render partial: 'games/board') %>');

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -211,5 +211,37 @@ RSpec.describe PiecesController, type: :controller do
       expect(promoted_pawn.piece_number).to eq 8
       expect(promoted_pawn.valid_move?(3, 7)).to eq true
     end
+
+    it 'puts White King in check upon Black Pawn promotion' do
+      game = create(:game)
+
+      sign_in game.player_one
+
+      black_pawn = create(:pawn, x_position: 0, y_position: 4, piece_number: 11, game_id: game.id)
+      white_king = create(:king, x_position: 2, y_position: 6, piece_number: 4, game_id: game.id)
+
+      put :promotion, params: { piece_id: black_pawn.id, id: black_pawn.id, promotion: 'Bishop',
+                                x_position: black_pawn.x_position, y_position: black_pawn.y_position, format: :js }
+
+      promoted_pawn = Piece.find(black_pawn.id)
+
+      expect(promoted_pawn.puts_enemy_in_check?(0, 4)).to eq true
+    end
+
+    it 'puts Black King in check upon White Pawn promotion' do
+      game = create(:game)
+
+      sign_in game.player_one
+
+      white_pawn = create(:pawn, x_position: 0, y_position: 4, piece_number: 5, game_id: game.id)
+      black_king = create(:king, x_position: 0, y_position: 6, piece_number: 10, game_id: game.id)
+
+      put :promotion, params: { piece_id: white_pawn.id, id: white_pawn.id, promotion: 'Rook',
+                                x_position: white_pawn.x_position, y_position: white_pawn.y_position, format: :js }
+
+      promoted_pawn = Piece.find(white_pawn.id)
+
+      expect(promoted_pawn.puts_enemy_in_check?(0, 4)).to eq true
+    end
   end
 end


### PR DESCRIPTION
This branch initiates the check? methods after a pawn is promoted. Highlights:

-Add a call to check? in `promotion.js.erb` which adds a flash message if a king is put in check due to pawn promotion

-`promotion.js.erb` now refreshes the board after the check? methods are ran

-Removed the `end_turn` method and combined it into `check_test` as it was reduced to just one line and didn't need to be in the game model. Plus it was misleadingly named. 

-Add logic for taking a threatening piece when a players own king is in check. It now allows a player to use their king to take a piece that has itself in check, as well as allowing a player to use any other piece they control to capture a piece that has their king in check. 

-Add some specs for checking if a king would be in check after a pawn is promoted. These tests do not actually simulate the full event of a promotion and the checks that happen right after, but they do ensure that a pawn that has been promoted is getting the proper valid_moves? upon promotion and that part of the check methods continue to work. 