### PR TITLE
Added check for pieces remaining in game.rb to speed up page load

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -118,6 +118,7 @@ class Game < ApplicationRecord
   def stalemate?(current_user)
     return false if state == 'Black King in Check.'
     return false if state == 'White King in Check.'
+    return false if enough_pieces_remaining(current_user.id == p1_id)
     return false if legal_moves(current_user.id == p1_id)
     return true
   end
@@ -134,6 +135,10 @@ class Game < ApplicationRecord
       end
     end
     return legal_moves.present?
+  end
+
+  def enough_pieces_remaining(white) # A check to not do legal moves if the player has enough remaining pieces
+    return playable_pieces(white).count > 3
   end
 
   def playable_pieces(white)

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe Game, type: :model do
       expect(@game.stalemate?(@player1)).to eq false
     end
 
+    it 'returns false if white player has more then three pieces' do
+      white_rook1 = create(:rook, x_position: 3, y_position: 3, game_id: @game.id, piece_number: 0)
+      white_rook2 = create(:rook, x_position: 5, y_position: 5, game_id: @game.id, piece_number: 0)
+      white_knight = create(:knight, x_position: 0, y_position: 1, game_id: @game.id, piece_number: 1)
+
+      expect(@game.stalemate?(@player1)).to eq false
+    end
+
     it 'returns false if white king can move out legally by taking piece' do
       black_rook = create(:rook, x_position: 2, y_position: 4, game_id: @game.id, piece_number: 6)
       black_rook2 = create(:rook, x_position: 1, y_position: 1, game_id: @game.id, piece_number: 6)
@@ -171,6 +179,14 @@ RSpec.describe Game, type: :model do
     end
 
     it 'returns false if black_king king can move' do
+      expect(@game.stalemate?(@player2)).to eq false
+    end
+
+    it 'returns false if black player has more then three pieces' do
+      black_rook = create(:rook, x_position: 1, y_position: 4, game_id: @game.id, piece_number: 6)
+      black_rook2 = create(:rook, x_position: 0, y_position: 5, game_id: @game.id, piece_number: 6)
+      black_queen = create(:queen, x_position: 3, y_position: 1, game_id: @game.id, piece_number: 9)
+
       expect(@game.stalemate?(@player2)).to eq false
     end
 


### PR DESCRIPTION
Just a quick line before legal moves would be run. I picked 3 as the magic number I think this would cover 99.99% of cases but that is Leroy Jenkins match so I am not for sure here. Probably could try to optimize legal moves a touch more but that will return that method to a very large mess.