### PR TITLE
Fix check alert

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -100,13 +100,12 @@ class PiecesController < ApplicationController
   end
 
   def check_test(piece, x, y)
-    return false if piece.can_take?(helpers.get_piece(x, y, piece.game)) && piece.type == 'King'
-
     if piece.puts_self_in_check?(x, y)
       flash.now[:alert] << 'You cannot put/leave yourself in Check.'
       return false
     end
 
+    return false if piece.can_take?(helpers.get_piece(x, y, piece.game)) && piece.type == 'King'
     return false unless piece.puts_enemy_in_check?(x, y)
 
     current_user.id == piece.game.p1_id ? 'Black King in Check.' : 'White King in Check.'

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -22,7 +22,7 @@ class PiecesController < ApplicationController
       @game.write_attribute(:state, nil)
     end
     @game.save
-    
+
     opponent = @game.opponent(current_user)
     ActionCable.server.broadcast "game_channel_user_#{opponent&.id}", move: render_movement, piece: @piece
   end
@@ -32,7 +32,7 @@ class PiecesController < ApplicationController
     @rook = Piece.find(params[:rook_id])
     @game = Game.find(@piece.game_id)
     @piece.castle!(@rook)
-    
+
     opponent = @game.opponent(current_user) 
     ActionCable.server.broadcast "game_channel_user_#{opponent&.id}", castle: render_movement, piece: @piece
   end
@@ -101,7 +101,6 @@ class PiecesController < ApplicationController
 
   def check_test(piece, x, y)
     return false if piece.can_take?(helpers.get_piece(x, y, piece.game)) && piece.type == 'King'
-    return false if piece.can_take?(helpers.get_piece(x, y, piece.game)) && !piece.puts_self_in_check?(x, y)
 
     if piece.puts_self_in_check?(x, y)
       flash.now[:alert] << 'You cannot put/leave yourself in Check.'

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -53,7 +53,6 @@ class Game < ApplicationRecord
     return (not player_two.nil?) ? player_two.email : "No Player Two"
   end
 
-  
   def check?(white)
     king = pieces_for_color(white).select { |piece| piece.type == 'King' }.first
     return false unless king
@@ -65,7 +64,6 @@ class Game < ApplicationRecord
   def pieces_for_color(white)
     pieces.select { |piece| piece.is_white? == white }
   end
-
 
   def checkmate?(white)
     return false unless check?(white)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -87,7 +87,7 @@ class Piece < ApplicationRecord
     pawn_moved_two = (last_move.start_x - last_move.final_x).abs == 2
     if last_move.start_piece == 5 && piece_number == 11 # White pawn moved past black pawn
       return pawn_moved_two && x == 2 && y == last_move.final_y
-    elsif last_move.start_piece == 11 && piece_number == 5# Black pawn moved past white pawn
+    elsif last_move.start_piece == 11 && piece_number == 5 # Black pawn moved past white pawn
       return pawn_moved_two && x == 5 && y == last_move.final_y
     else
       return false

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -143,6 +143,7 @@ class Piece < ApplicationRecord
 
   def puts_enemy_in_check?(x, y)
     previous_attributes = attributes
+
     begin
       update(x_position: x, y_position: y)
       game.pieces.reload

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe PiecesController, type: :controller do
       white_king = create(:king, x_position: 0, y_position: 4, game_id: @game.id, piece_number: 4)
       white_pawn = create(:pawn, x_position: 0, y_position: 5, game_id: @game.id, piece_number: 5)
       black_rook = create(:rook, x_position: 0, y_position: 7, game_id: @game.id, piece_number: 6)
+      create(:move, game_id: @game.id, piece_id: white_pawn.id, start_piece: 5)
 
       sign_in @player2
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -155,18 +155,18 @@ RSpec.describe PiecesController, type: :controller do
       expect(@game.winner).to eq @player2
     end
 
-    it 'game in check when black piece takes a white piece and puts white king in check' do
+    it 'puts game in check when black piece takes a white piece and puts white king in check' do
       white_king = create(:king, x_position: 0, y_position: 4, game_id: @game.id, piece_number: 4)
       white_pawn = create(:pawn, x_position: 0, y_position: 5, game_id: @game.id, piece_number: 5)
       black_rook = create(:rook, x_position: 0, y_position: 7, game_id: @game.id, piece_number: 6)
 
       sign_in @player2
 
-      # put :update, params: { id: black_rook.id, x_position: 0, y_position: 5, format: :js }
       black_rook.move_to!(0, 5)
       white_pawn.reload
       black_rook.reload
       @game.reload
+
       expect(black_rook.x_position).to eq 0
       expect(black_rook.y_position).to eq 5
       expect(@game.check?(!black_rook.is_white?)).to eq true

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PiecesController, type: :controller do
 
     it 'should require users to be logged in' do
       game = create(:game)
-      
+
       piece = create(:piece, game_id: game.id, piece_number: 5, x_position: 1, y_position: 7)
 
       patch :update, params: { id: piece.id, piece: {x_position: 3, y_position: 7}}
@@ -72,7 +72,7 @@ RSpec.describe PiecesController, type: :controller do
 
       put :update, params: {id: @white_pawn.id, x_position: 3, y_position: 0, format: :js }
       @white_pawn.reload
-      
+
       expect(@white_pawn.x_position).to eq 1
       expect(@white_pawn.y_position).to eq 0
     end
@@ -93,9 +93,9 @@ RSpec.describe PiecesController, type: :controller do
       white_rook2 = create(:rook, x_position: 6, y_position: 5, game_id: @game.id, piece_number: 0)
       white_rook3 = create(:rook, x_position: 3, y_position: 2, game_id: @game.id, piece_number: 0)
       white_rook4 = create(:rook, x_position: 5, y_position: 6, game_id: @game.id, piece_number: 0)
-      
+
       sign_in @player1
-      
+
       put :update, params: {id: white_queen.id, x_position: 3, y_position: 3, format: :js }
       white_queen.reload
       @game.reload
@@ -107,7 +107,7 @@ RSpec.describe PiecesController, type: :controller do
     it 'should not allow black players to move white pieces' do
       white_pawn = create(:pawn, x_position: 1, y_position: 2, piece_number: 5, game_id: @game.id)
       move = create(:move, game_id: @game.id, piece_id: white_pawn.id, start_piece: 5)
-      
+
       sign_in @player2
 
       put :update, params: {id: @white_pawn.id, x_position: 3, y_position: 0, format: :js }

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe PiecesController, type: :controller do
       @player1 = create(:user)
       @player2 = create(:user)
       @game = create(:game, name: 'Testerroni Pizza',
-        p1_id: @player1.id, p2_id: @player2.id,
-        creating_user_id: @player1.id, invited_user_id: @player2.id)
+                     p1_id: @player1.id, p2_id: @player2.id,
+                     creating_user_id: @player1.id, invited_user_id: @player2.id)
       @white_pawn = create(:pawn, x_position: 1, y_position: 0, piece_number: 5, game_id: @game.id)
       @black_pawn = create(:pawn, x_position: 6, y_position: 1, piece_number: 11, game_id: @game.id)
     end
@@ -28,7 +28,7 @@ RSpec.describe PiecesController, type: :controller do
 
       sign_in user
 
-      put :update, params: {id: piece.id, x_position: 3, y_position: 0, format: :js }
+      put :update, params: { id: piece.id, x_position: 3, y_position: 0, format: :js }
       piece.reload
       expect(flash[:alert]).to eq ['No second player!']
       expect(piece.x_position).to eq 1
@@ -45,7 +45,7 @@ RSpec.describe PiecesController, type: :controller do
 
       sign_in player1
 
-      put :update, params: {id: piece.id, x_position: 3, y_position: 0, format: :js }
+      put :update, params: { id: piece.id, x_position: 3, y_position: 0, format: :js }
       piece.reload
       game.reload
       expect(flash[:alert]).to eq ['This game ended in a draw!']
@@ -57,7 +57,7 @@ RSpec.describe PiecesController, type: :controller do
     it 'should not allow white players to move black pieces' do
       sign_in @player1
 
-      put :update, params: {id: @black_pawn.id, x_position: 4, y_position: 1, format: :js }
+      put :update, params: { id: @black_pawn.id, x_position: 4, y_position: 1, format: :js }
       @black_pawn.reload
       expect(flash[:alert]).to eq ['Not your piece!']
       expect(@black_pawn.x_position).to eq 6
@@ -70,7 +70,7 @@ RSpec.describe PiecesController, type: :controller do
 
       sign_in @player1
 
-      put :update, params: {id: @white_pawn.id, x_position: 3, y_position: 0, format: :js }
+      put :update, params: { id: @white_pawn.id, x_position: 3, y_position: 0, format: :js }
       @white_pawn.reload
 
       expect(@white_pawn.x_position).to eq 1
@@ -80,7 +80,7 @@ RSpec.describe PiecesController, type: :controller do
     it 'allows white players to move white pieces' do
       sign_in @player1
 
-      put :update, params: {id: @white_pawn.id, x_position: 3, y_position: 0, format: :js }
+      put :update, params: { id: @white_pawn.id, x_position: 3, y_position: 0, format: :js }
       @white_pawn.reload
       expect(@white_pawn.x_position).to eq 3
       expect(@white_pawn.y_position).to eq 0
@@ -96,7 +96,7 @@ RSpec.describe PiecesController, type: :controller do
 
       sign_in @player1
 
-      put :update, params: {id: white_queen.id, x_position: 3, y_position: 3, format: :js }
+      put :update, params: { id: white_queen.id, x_position: 3, y_position: 3, format: :js }
       white_queen.reload
       @game.reload
       expect(white_queen.x_position).to eq 3
@@ -110,7 +110,7 @@ RSpec.describe PiecesController, type: :controller do
 
       sign_in @player2
 
-      put :update, params: {id: @white_pawn.id, x_position: 3, y_position: 0, format: :js }
+      put :update, params: { id: @white_pawn.id, x_position: 3, y_position: 0, format: :js }
 
       expect(flash[:alert]).to eq ['Not your piece!']
       expect(@white_pawn.x_position).to eq 1
@@ -120,7 +120,7 @@ RSpec.describe PiecesController, type: :controller do
     it 'should not allow black players to move pieces on white players turn' do
       sign_in @player2
 
-      put :update, params: {id: @black_pawn.id, x_position: 4, y_position: 1, format: :js }
+      put :update, params: { id: @black_pawn.id, x_position: 4, y_position: 1, format: :js }
       @black_pawn.reload
       expect(@black_pawn.x_position).to eq 6
       expect(@black_pawn.y_position).to eq 1
@@ -132,7 +132,7 @@ RSpec.describe PiecesController, type: :controller do
 
       sign_in @player2
 
-      put :update, params: {id: @black_pawn.id, x_position: 4, y_position: 1, format: :js }
+      put :update, params: { id: @black_pawn.id, x_position: 4, y_position: 1, format: :js }
       @black_pawn.reload
       expect(@black_pawn.x_position).to eq 4
       expect(@black_pawn.y_position).to eq 1
@@ -147,12 +147,29 @@ RSpec.describe PiecesController, type: :controller do
 
       sign_in @player2
 
-      put :update, params: {id: black_queen.id, x_position: 1, y_position: 6, format: :js }
+      put :update, params: { id: black_queen.id, x_position: 1, y_position: 6, format: :js }
       black_queen.reload
       @game.reload
       expect(black_queen.x_position).to eq 1
       expect(black_queen.y_position).to eq 6
       expect(@game.winner).to eq @player2
+    end
+
+    it 'game in check when black piece takes a white piece and puts white king in check' do
+      white_king = create(:king, x_position: 0, y_position: 4, game_id: @game.id, piece_number: 4)
+      white_pawn = create(:pawn, x_position: 0, y_position: 5, game_id: @game.id, piece_number: 5)
+      black_rook = create(:rook, x_position: 0, y_position: 7, game_id: @game.id, piece_number: 6)
+
+      sign_in @player2
+
+      # put :update, params: { id: black_rook.id, x_position: 0, y_position: 5, format: :js }
+      black_rook.move_to!(0, 5)
+      white_pawn.reload
+      black_rook.reload
+      @game.reload
+      expect(black_rook.x_position).to eq 0
+      expect(black_rook.y_position).to eq 5
+      expect(@game.check?(!black_rook.is_white?)).to eq true
     end
   end
 


### PR DESCRIPTION
Fixes #101 

-Removed a line in `check_test` which was causing issues with alerting for check when an enemy piece was captured which in turn put the enemy king in check. 

-Removed some white space

-Added a spec to show that a game would be in check after an enemy piece is captured which in turn puts the enemy king in check. 