### PR TITLE
Add revert option for draggable jQuery

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -20,6 +20,7 @@
   function init_draggables_and_droppables() { 
       $('.piece').draggable({
         containment: '.gameboard',
+        revert: 'invalid', 
         snap: '.tile',
         cursor: 'crosshair',
         scroll: false


### PR DESCRIPTION
Fixes #102 

-Add revert option to JQuery draggable class for invalid moves
  -This will cause the piece to float back to it's original position if it is dragged outside of the containment class specified. 